### PR TITLE
LogLevelFilter parameter to init_* functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,25 +143,25 @@ pub fn tcp<T: ToSocketAddrs>(server: T, hostname: String, facility: Facility) ->
 }
 
 /// Unix socket Logger init function compatible with log crate
-#[allow(unused_variables)]
-pub fn init_unix(facility: Facility) -> Result<(), SetLoggerError> {
+pub fn init_unix(facility: Facility, log_level: log::LogLevelFilter) -> Result<(), SetLoggerError> {
   log::set_logger(|max_level| {
+    max_level.set(log_level);
     unix(facility).unwrap()
   })
 }
 
 /// UDP Logger init function compatible with log crate
-#[allow(unused_variables)]
-pub fn init_udp<T: ToSocketAddrs>(local: T, server: T, hostname:String, facility: Facility) -> Result<(), SetLoggerError> {
+pub fn init_udp<T: ToSocketAddrs>(local: T, server: T, hostname:String, facility: Facility, log_level: log::LogLevelFilter) -> Result<(), SetLoggerError> {
   log::set_logger(|max_level| {
+    max_level.set(log_level);
     udp(local, server, hostname, facility).unwrap()
   })
 }
 
 /// TCP Logger init function compatible with log crate
-#[allow(unused_variables)]
-pub fn init_tcp<T: ToSocketAddrs>(server: T, hostname: String, facility: Facility) -> Result<(), SetLoggerError> {
+pub fn init_tcp<T: ToSocketAddrs>(server: T, hostname: String, facility: Facility, log_level: log::LogLevelFilter) -> Result<(), SetLoggerError> {
   log::set_logger(|max_level| {
+    max_level.set(log_level);
     tcp(server, hostname, facility).unwrap()
   })
 }


### PR DESCRIPTION
Unless `max_level.set` is called nothing will ever be logged.  I found out the hard way that currently only the `init` function is usable for `log` crate support.