### PR TITLE
Adding ability to filter logging with environmental variables.  

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ unix_socket = "~0.4.4"
 libc        = "~0.1"
 time        = "~0.1"
 log         = "~0.3.1"
+regex       = "0.1.73"
 
 [features]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ There are 3 functions to create loggers:
 * the `unix` function sends to the local syslog through a Unix socket: `syslog::unix(Facility::LOG_USER)`
 * the `tcp` function takes an address for a remote TCP syslog server and a hostname: `tcp("127.0.0.1:4242", "localhost".to_string(), Facility::LOG_USER)`
 * the `udp` function takes an address for a local port, and the address remote UDP syslog server and a hostname: `udp("127.0.0.1:1234", "127.0.0.1:4242", "localhost".to_string(), Facility::LOG_USER)`
+
+This crate supports filtering similar to the [env_logger](https://crates.io/crates/env_logger) crate when using the logging facade provided by [log](https://crates.io/crates/log).  You can use their [documentation](http://burntsushi.net/rustdoc/env_logger/index.html#enabling-logging) for any questions. It should be functionally identical except one small difference.  env_logger defaults to filtering out all log messages when the environmental variable RUST_LOG is not set, where this crate defaults to the log level filter used in the init function.   The environmental variable acts like an override for what you pass in during init.
+
+To use the facade, simply setup up logger:
+```rust
+syslog::init(Facility::LOG_USER,LogLevelFilter::Trace,Some("yourmodule")).unwrap();
+```
+And then use the methods provided by the logging crate:
+```rust
+info!("Log at info");
+error!("Log at error");
+```
+If you run the previous code with RUST_LOG=yourmodule=error then you will only see the error log and the info line will be filtered.


### PR DESCRIPTION
I'm working on a project and really wanted the ability to filter logging without a re-compile that env_logger provides but also wanted to syslog.  I've pulled their filtering code over so I can have the best of both worlds.  If the RUST_LOG env isn't set it should affect how the library works.
