### PR TITLE
Added `set_facility` method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,11 @@ impl Logger {
   pub fn set_process_id(&mut self, id: i32) {
     self.pid = id
   }
+  
+  /// Changes facility
+  pub fn set_facility(&mut self, facility: Facility) {
+    self.facility = facility;
+  }
 }
 
 #[allow(unused_variables,unused_must_use)]


### PR DESCRIPTION
This method allows to change facility run-time. One use case is when facility needs to be configured and failure to read config file should be logged with some default facility.