### PR TITLE
Fix Travis script to fail the build if error occurs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 
 script:
-  - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo bench
-      travis-cargo --only stable doc
+  - travis-cargo build
+  - travis-cargo test
+  - travis-cargo bench
+  - travis-cargo --only stable doc
 
 after_success:
   - travis-cargo coveralls --no-sudo


### PR DESCRIPTION
Master has been broken, but Travis hid the fact. This pull request fixes the hidden failure to be visible.

This pull request is supposed to fail to show that master is currently not building correctly.
  