### PR TITLE
Update tests to use new interface

### DIFF
--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,12 +1,20 @@
 extern crate syslog;
 
-use syslog::{Facility,Severity};
+use syslog::{Facility,Formatter3164};
 
 fn main() {
-  match syslog::unix(Facility::LOG_USER) {
+
+ let formatter = Formatter3164 {
+   facility: Facility::LOG_USER,
+   hostname: None,
+   process:  "process".to_string(),
+   pid:      1234,
+ };
+
+  match syslog::unix(formatter) {
     Err(e)         => println!("impossible to connect to syslog: {:?}", e),
-    Ok(writer) => {
-      let r = writer.send(Severity::LOG_ALERT, "hello world");
+    Ok(mut logger) => {
+      let r = logger.alert("hello world");
       if r.is_err() {
         println!("error sending the log {}", r.err().expect("got error"));
       }


### PR DESCRIPTION
The tests and examples used the unix function which now requires a
formatter to be specified instead of a facility.