### PR TITLE
Remove dependency to unix_socket and use std instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://docs.rs/syslog"
 keywords = ["syslog", "logs", "logging"]
 
 [dependencies]
-unix_socket = "^0.5"
 libc        = "^0.2"
 time        = "^0.1"
 log         = { version =  "^0.4.1", features = [ "std" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@
 #![crate_type = "lib"]
 
 #[macro_use] extern crate error_chain;
-extern crate unix_socket;
 extern crate libc;
 extern crate time;
 extern crate log;
@@ -45,9 +44,9 @@ use std::io::{self, BufWriter, Write};
 use std::sync::{Arc,Mutex};
 use std::marker::PhantomData;
 use std::net::{SocketAddr,ToSocketAddrs,UdpSocket,TcpStream};
+use std::os::unix::net::{UnixDatagram, UnixStream};
 
 use libc::getpid;
-use unix_socket::{UnixDatagram, UnixStream};
 use log::{Log, Metadata, Record, Level};
 
 mod facility;


### PR DESCRIPTION
UNIX sockets are provided by Rust's standard library since 1.10.