### PR TITLE
Fix Clippy nags

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -97,12 +97,12 @@ impl Formatter5424 {
       "-".to_string()
     } else {
       let mut res = String::new();
-      for (id, params) in data.iter() {
+      for (id, params) in &data {
         res = res + "["+id;
-        for (name,value) in params.iter() {
+        for (name,value) in params {
           res = res + " " + name + "=\"" + value + "\"";
         }
-        res = res + "]";
+        res += "]";
       }
 
       res
@@ -125,5 +125,5 @@ impl<T: Display> LogFormat<(i32, StructuredData, T)> for Formatter5424 {
 }
 
 fn encode_priority(severity: Severity, facility: Facility) -> Priority {
-  return facility as u8 | severity as u8
+  facility as u8 | severity as u8
 }


### PR DESCRIPTION
Fix Clippy nags. There should be no functional change.

One warning left unfixed since it would change the API:

```
warning: this argument is passed by value, but not consumed in the function body
  --> src/format.rs:95:51
   |
95 |   pub fn format_5424_structured_data(&self, data: StructuredData) -> String {
   |                                                   ^^^^^^^^^^^^^^ help: consider taking a reference instead: `&StructuredData`
   |
   = note: #[warn(needless_pass_by_value)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.192/index.html#needless_pass_by_value
```
