### PR TITLE
cargo: expose error-chain backtrace as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ keywords = ["syslog", "logs", "logging"]
 libc        = "^0.2"
 time        = "^0.1"
 log         = { version =  "^0.4.1", features = [ "std" ] }
-error-chain = "^0.11.0"
+error-chain = { version = "^0.11.0", default-features = false }
 
 [features]
 nightly = []
+backtrace = ["error-chain/backtrace"]


### PR DESCRIPTION
This forwards error-chain "backtrace" feature as a feature of this
crate. This is to allow consumers to directly control whether to turn
it on, as opposed to being always-on and hidden behind the transitive
dependency. As cargo features are additive, this is opt-in and not
enabled by default.