### PR TITLE
Fix RFC 5424 Format

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -114,7 +114,7 @@ impl<T: Display> LogFormat<(i32, StructuredData, T)> for Formatter5424 {
   fn format<W: Write>(&self, w: &mut W, severity: Severity, log_message: (i32, StructuredData, T))   -> Result<()> {
     let (message_id, data, message) = log_message;
 
-    write!(w, "<{}> {} {} {} {} {} {} {} {}",
+    write!(w, "<{}>{} {} {} {} {} {} {} {}",
       encode_priority(severity, self.facility),
       1, // version
       time::now_utc().rfc3339(),


### PR DESCRIPTION
The official format for RFC 5424 does not include a space before the version number (see [The Syslog Protocol - Examples](https://tools.ietf.org/html/rfc5424#section-6.5)).
What is more, the [telegraf](https://github.com/influxdata/telegraf) syslog input only accepts the format this way.