### PR TITLE
src/format: use chrono not time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "syslog"
 version = "5.0.0"
 authors = [ "contact@geoffroycouprie.com" ]
@@ -10,8 +9,8 @@ documentation = "https://docs.rs/syslog"
 keywords = ["syslog", "logs", "logging"]
 
 [dependencies]
+chrono      = "^0.4"
 libc        = "^0.2"
-time        = "^0.1"
 log         = { version =  "^0.4", features = [ "std" ] }
 error-chain = { version = "^0.12", default-features = false }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,4 @@
-use time;
+use chrono::offset::{Local, Utc};
 use std::io::Write;
 use std::fmt::Display;
 use std::collections::HashMap;
@@ -69,12 +69,12 @@ impl<T: Display> LogFormat<T> for Formatter3164 {
     if let Some(ref hostname) = self.hostname {
         write!(w, "<{}>{} {} {}[{}]: {}",
           encode_priority(severity, self.facility),
-          time::now().strftime("%b %d %T").unwrap(),
+          Local::now().format("%b %d %T"),
           hostname, self.process, self.pid, message).chain_err(|| ErrorKind::Format)
     } else {
         write!(w, "<{}>{} {}[{}]: {}",
           encode_priority(severity, self.facility),
-          time::now().strftime("%b %d %T").unwrap(),
+          Local::now().format("%b %d %T"),
           self.process, self.pid, message).chain_err(|| ErrorKind::Format)
     }
   }
@@ -117,7 +117,7 @@ impl<T: Display> LogFormat<(i32, StructuredData, T)> for Formatter5424 {
     write!(w, "<{}> {} {} {} {} {} {} {} {}",
       encode_priority(severity, self.facility),
       1, // version
-      time::now_utc().rfc3339(),
+      Utc::now().to_rfc3339(),
       self.hostname.as_ref().map(|x| &x[..]).unwrap_or("localhost"),
       self.process, self.pid, message_id,
       self.format_5424_structured_data(data), message).chain_err(|| ErrorKind::Format)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,9 @@
 //!
 #![crate_type = "lib"]
 
+extern crate chrono;
 #[macro_use] extern crate error_chain;
 extern crate libc;
-extern crate time;
 extern crate log;
 
 use std::env;


### PR DESCRIPTION
The time crate has been largely abandoned, so instead of updating to
time 0.2, we are jumping ship to chrono, the spirtual sucessor.

Source has been formatted and linted via rustfmt and clippy. Some other
dependencies were also upgraded.