### PR TITLE
Add check for global filtering levels in Log::enabled() impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ impl BasicLogger {
 #[allow(unused_variables,unused_must_use)]
 impl Log for BasicLogger {
   fn enabled(&self, metadata: &Metadata) -> bool {
-    true
+    metadata.level() <= log::max_level() && metadata.level() <= log::STATIC_MAX_LEVEL
   }
 
   fn log(&self, record: &Record) {


### PR DESCRIPTION
The check mimics the ones used by the `log!()` macro.

The `enabled()` function is used by the `log_enabled!()` macro. I stumbled over this when activating logging for a `hyper` server, which uses its own tracing framework. If `enabled()` always returns `true`, `hyper` will happily spam syslog with trace-level messages despite the filtering having been initialized in `syslog::init_unix()` or equivalent.