### PR TITLE
Specify minimal dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["syslog", "logs", "logging"]
 
 [dependencies]
 libc        = "^0.2"
-time        = "^0.1"
+time        = "^0.1.34"
 log         = { version =  "^0.4", features = [ "std" ] }
-error-chain = { version = "^0.12", default-features = false }
+error-chain = { version = "^0.12.2", default-features = false }
 
 [features]
 nightly = []


### PR DESCRIPTION
The proposed change updates the dependency versions such that the crate may be compiled using the minimal version of all dependencies.

I used the command `cargo +nightly update -Z minimal-versions` to downgrade all dependencies to the minimal version and then ran `cargo test` to verify.

I don’t know if you’re interested in this change, but it helps downstream consumers of syslog to make minimal version guarantees.
