### PR TITLE
Replace error-chain with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["syslog", "logs", "logging"]
 hostname    = "0.3.1"
 time        = { version = "0.3.5", features = ["local-offset", "formatting"] }
 log         = { version = "0.4.8", features = [ "std" ] }
-error-chain = { version = "0.12.2", default-features = false }
+thiserror = "1.0"
 libc = "0.2.112"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,21 @@
-error_chain! {
-    errors { Initialization UnsupportedPlatform Format Write }
-
-    foreign_links {
-        Io(::std::io::Error) #[doc = "Link to a `std::error::Error` type."];
-    }
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("initialization: {0}")]
+    Initialization(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("cannot find process file name")]
+    ProcessHasNoFilename,
+    #[error("not a valid UTF-8 string")]
+    NonUtf8OsStr,
+    #[error("unsupported platform")]
+    UnsupportedPlatform,
+    #[error("cannot find a valid unix socket to local syslog")]
+    NoValidUnixSocket,
+    #[error("not a valid socket address")]
+    InvalidSocketAddr,
+    #[error("format: {0}")]
+    Format(#[source] std::io::Error),
+    #[error("IO: {0}")]
+    Io(#[from] std::io::Error),
 }
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/format.rs
+++ b/src/format.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::io::Write;
 use time;
 
-use errors::*;
+use errors::{Error, Result};
 use facility::Facility;
 use get_hostname;
 use get_process_info;
@@ -85,7 +85,7 @@ impl<T: Display> LogFormat<T> for Formatter3164 {
                 self.pid,
                 message
             )
-            .chain_err(|| ErrorKind::Format)
+            .map_err(Error::Format)
         } else {
             write!(
                 w,
@@ -98,7 +98,7 @@ impl<T: Display> LogFormat<T> for Formatter3164 {
                 self.pid,
                 message
             )
-            .chain_err(|| ErrorKind::Format)
+            .map_err(Error::Format)
         }
     }
 }
@@ -186,7 +186,7 @@ impl<T: Display> LogFormat<(u32, StructuredData, T)> for Formatter5424 {
             self.format_5424_structured_data(data),
             message
         )
-        .chain_err(|| ErrorKind::Format)
+        .map_err(Error::Format)
     }
 }
 


### PR DESCRIPTION
Package error-chain has not been updated for 3 years and its git repo has been archived:
https://github.com/rust-lang-deprecated/error-chain.

This commit replaces error-chain with thiserror.