### PR TITLE
Don't set hostname with the UNIX socket backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,17 +490,18 @@ pub fn init(
         pid,
     };
 
-    let backend = unix(formatter.clone())
-        .map(|logger: Logger<LoggerBackend, Formatter3164>| logger.backend)
-        .or_else(|_| {
-            formatter.hostname = get_hostname().ok();
-            TcpStream::connect(("127.0.0.1", 601))
-                .map(|s| LoggerBackend::Tcp(BufWriter::new(s)))
-                .or_else(|_| {
-                    let udp_addr = "127.0.0.1:514".parse().unwrap();
-                    UdpSocket::bind(("127.0.0.1", 0)).map(|s| LoggerBackend::Udp(s, udp_addr))
-                })
-        })?;
+    let backend = if let Ok(logger) = unix(formatter.clone()) {
+        logger.backend
+    } else {
+        formatter.hostname = get_hostname().ok();
+        if let Ok(tcp_stream) = TcpStream::connect(("127.0.0.1", 601)) {
+            LoggerBackend::Tcp(BufWriter::new(tcp_stream))
+        } else {
+            let udp_addr = "127.0.0.1:514".parse().unwrap();
+            let udp_stream = UdpSocket::bind(("127.0.0.1", 0))?;
+            LoggerBackend::Udp(udp_stream, udp_addr)
+        }
+    };
     log::set_boxed_logger(Box::new(BasicLogger::new(Logger { formatter, backend })))
         .chain_err(|| ErrorKind::Initialization)?;
 


### PR DESCRIPTION
Users of the generic `init()` function experience a weird rendering when the UNIX socket backend is selected, e.g.

```
Jan 12 17:03:04 myhostname virtiofsd[70727]: myhostname virtiofsd[70725]: Waiting for vhost-user socket connection...
```

Notice that the `hostname` and `process[pid]` name appear twice. Pids are different because virtiofsd forks at some point ; 70725 is the pid of the virtiofsd process that called `init()` and 70727 is the pid of the child.

This seems to be the result of `init()` setting the `hostname` of the `formatter` unconditionally, while `init_unix()` and the documentation suggest to set it to `None`.

First patch makes sure that `None` is used in the UNIX case. Second patch is a cosmetic change to make the code more readable.
