### PR TITLE
fix: escape structured data and enforce micro precision per rfc5424

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -150,7 +150,12 @@ impl Formatter5424 {
             for (id, params) in &data {
                 res = res + "[" + id;
                 for (name, value) in params {
-                    res = res + " " + name + "=\"" + value + "\"";
+                    res = res
+                        + " "
+                        + name
+                        + "=\""
+                        + &escape_structure_data_param_value(&value)
+                        + "\"";
                 }
                 res += "]";
             }
@@ -169,11 +174,19 @@ impl<T: Display> LogFormat<(u32, StructuredData, T)> for Formatter5424 {
     ) -> Result<()> {
         let (message_id, data, message) = log_message;
 
+        // Guard against sub-second precision over 6 digits per rfc5424 section 6
+        let timestamp = time::OffsetDateTime::now_utc();
+        // SAFETY: timestamp range is enforced, so this will never fail
+        let timestamp = timestamp
+            // Removing significant figures beyond 6 digits (nanoseconds to microseconds)
+            .replace_nanosecond(timestamp.microsecond())
+            .unwrap();
+
         write!(
             w,
             "<{}>1 {} {} {} {} {} {} {}", // v1
             encode_priority(severity, self.facility),
-            time::OffsetDateTime::now_utc()
+            timestamp
                 .format(&time::format_description::well_known::Rfc3339)
                 .unwrap(),
             self.hostname
@@ -221,6 +234,13 @@ impl Default for Formatter5424 {
     }
 }
 
+fn escape_structure_data_param_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace(']', "\\]")
+}
+
 fn encode_priority(severity: Severity, facility: Facility) -> Priority {
     facility as u8 | severity as u8
 }
@@ -237,42 +257,66 @@ fn now_local() -> std::result::Result<time::OffsetDateTime, time::error::Indeter
     time::OffsetDateTime::now_local()
 }
 
-#[test]
-fn test_formatter3164_defaults() {
-    let d = Formatter3164::default();
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    // `Facility` doesn't implement `PartialEq`, so we use a `match` instead.
-    assert!(match d.facility {
-        Facility::LOG_USER => true,
-        _ => false,
-    });
+    #[test]
+    fn backslash_is_escaped() {
+        let string = "\\";
+        let value = escape_structure_data_param_value(string);
+        assert_eq!(value, "\\\\");
+    }
+    #[test]
+    fn quote_is_escaped() {
+        let string = "foo\"bar";
+        let value = escape_structure_data_param_value(string);
+        assert_eq!(value, "foo\\\"bar");
+    }
+    #[test]
+    fn end_bracket_is_escaped() {
+        let string = "]";
+        let value = escape_structure_data_param_value(string);
+        assert_eq!(value, "\\]");
+    }
 
-    assert!(match &d.hostname {
-        Some(hostname) => !hostname.is_empty(),
-        None => false,
-    });
+    #[test]
+    fn test_formatter3164_defaults() {
+        let d = Formatter3164::default();
 
-    assert!(!d.process.is_empty());
+        // `Facility` doesn't implement `PartialEq`, so we use a `match` instead.
+        assert!(match d.facility {
+            Facility::LOG_USER => true,
+            _ => false,
+        });
 
-    // Can't really make any assertions about the pid.
-}
+        assert!(match &d.hostname {
+            Some(hostname) => !hostname.is_empty(),
+            None => false,
+        });
 
-#[test]
-fn test_formatter5424_defaults() {
-    let d = Formatter5424::default();
+        assert!(!d.process.is_empty());
 
-    // `Facility` doesn't implement `PartialEq`, so we use a `match` instead.
-    assert!(match d.facility {
-        Facility::LOG_USER => true,
-        _ => false,
-    });
+        // Can't really make any assertions about the pid.
+    }
 
-    assert!(match &d.hostname {
-        Some(hostname) => !hostname.is_empty(),
-        None => false,
-    });
+    #[test]
+    fn test_formatter5424_defaults() {
+        let d = Formatter5424::default();
 
-    assert!(!d.process.is_empty());
+        // `Facility` doesn't implement `PartialEq`, so we use a `match` instead.
+        assert!(match d.facility {
+            Facility::LOG_USER => true,
+            _ => false,
+        });
 
-    // Can't really make any assertions about the pid.
+        assert!(match &d.hostname {
+            Some(hostname) => !hostname.is_empty(),
+            None => false,
+        });
+
+        assert!(!d.process.is_empty());
+
+        // Can't really make any assertions about the pid.
+    }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -178,8 +178,8 @@ impl<T: Display> LogFormat<(u32, StructuredData, T)> for Formatter5424 {
         let timestamp = time::OffsetDateTime::now_utc();
         // SAFETY: timestamp range is enforced, so this will never fail
         let timestamp = timestamp
-            // Removing significant figures beyond 6 digits (nanoseconds to microseconds)
-            .replace_nanosecond(timestamp.microsecond())
+            // Removing significant figures beyond 6 digits
+            .replace_nanosecond(timestamp.nanosecond() / 1000 * 1000)
             .unwrap();
 
         write!(


### PR DESCRIPTION
- ensure timestamp's sub-seconds is no more than 6 digits of precision (by using microseconds)
  - per section 6 of rfc5424
```
      TIME-SECFRAC    = "." 1*6DIGIT
```
(also re-iterated in section 6.2.3)
```
   Example 5 - An Invalid TIMESTAMP

         2003-08-24T05:14:15.000000003-07:00

   This example is nearly the same as Example 4, but it is specifying
   TIME-SECFRAC in nanoseconds.  This results in TIME-SECFRAC being
   longer than the allowed 6 digits, which invalidates it.
```
- escape structured data values
  - per section 6.3.3 of rfc5424
```
   Inside PARAM-VALUE, the characters '"' (ABNF %d34), '\' (ABNF %d92),
   and ']' (ABNF %d93) MUST be escaped. 
```

Resolves: #73