### PR TITLE
fix(log): add log filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,16 +343,18 @@ impl Log for BasicLogger {
     }
 
     fn log(&self, record: &Record) {
-        //FIXME: temporary patch to compile
-        let message = format!("{}", record.args());
-        let mut logger = self.logger.lock().unwrap();
-        match record.level() {
-            Level::Error => logger.err(message),
-            Level::Warn => logger.warning(message),
-            Level::Info => logger.info(message),
-            Level::Debug => logger.debug(message),
-            Level::Trace => logger.debug(message),
-        };
+        if self.enabled(record.metadata()) {
+            //FIXME: temporary patch to compile
+            let message = format!("{}", record.args());
+            let mut logger = self.logger.lock().unwrap();
+            match record.level() {
+                Level::Error => logger.err(message),
+                Level::Warn => logger.warning(message),
+                Level::Info => logger.info(message),
+                Level::Debug => logger.debug(message),
+                Level::Trace => logger.debug(message),
+            };
+        }
     }
 
     fn flush(&self) {


### PR DESCRIPTION
Added log filtering to this crate.
As described in the `Log` trait documentation, the log-implementation is responsible for filtering the logs:

https://github.com/rust-lang/log/blob/c879b011a8ac662545adf9484d9a668ebcf9b814/src/lib.rs#L1178C6-L1182
```rust
    /// Logs the `Record`.
    ///
    /// # For implementors
    ///
    /// Note that `enabled` is *not* necessarily called before this method.
    /// Implementations of `log` should perform all necessary filtering
    /// internally.
    fn log(&self, record: &Record);
```

